### PR TITLE
Load helm-mode.el for using helm-comp-read

### DIFF
--- a/helm-ext-ff.el
+++ b/helm-ext-ff.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'helm-files)
+(require 'helm-mode)
 
 (defvar helm-ext-ff-skipping-dots-recenter nil
   "If t, recenter after skipping the dots.")


### PR DESCRIPTION
This suppresses a byte-compile warning.