### PR TITLE
Add horizontal/vertical split in helm-find-files and helm-buffer

### DIFF
--- a/helm-ext-ff.el
+++ b/helm-ext-ff.el
@@ -380,6 +380,7 @@ If PATTERN is a valid directory name,return PATTERN unchanged."
 
 (defvar helm-ext-ff-horizontal-split-key "C-c s h")
 (defvar helm-ext-ff-vertical-split-key "C-c s v")
+(defvar helm-ext-ff-split-actions-keymaps (list helm-find-files-map helm-buffer-map))
 
 (defun helm-ext-ff-action-horizontal-split (candidate)
   (dolist (buf (helm-marked-candidates))

--- a/helm-ext-ff.el
+++ b/helm-ext-ff.el
@@ -362,5 +362,50 @@ If PATTERN is a valid directory name,return PATTERN unchanged."
            (with-helm-window
              (recenter-top-bottom 0))))))
 
+(defvar helm-ext-ff--horizontal-split-action
+  '("Find file in horizontal split" .
+    helm-ext-ff-action-horizontal-split))
+
+(defvar helm-ext-ff--vertical-split-action
+  '("Find file in vertical split" .
+    helm-ext-ff-action-vertical-split))
+
+(defvar helm-ext-ff--buffer-horizontal-split-action
+  '("View buffer in horizontal split" .
+    helm-ext-ff-action-horizontal-split))
+
+(defvar helm-ext-ff--buffer-vertical-split-action
+  '("View buffer in vertical split" .
+    helm-ext-ff-action-vertical-split))
+
+(defvar helm-ext-ff-horizontal-split-key "C-c s h")
+(defvar helm-ext-ff-vertical-split-key "C-c s v")
+
+(defun helm-ext-ff-action-horizontal-split (candidate)
+  (dolist (buf (helm-marked-candidates))
+    (select-window (split-window-below))
+    (if (get-buffer buf)
+        (switch-to-buffer buf)
+      (find-file buf)))
+  (balance-windows))
+
+(defun helm-ext-ff-action-vertical-split (candidate)
+  (dolist (buf (helm-marked-candidates))
+    (select-window (split-window-right))
+    (if (get-buffer buf)
+        (switch-to-buffer buf)
+      (find-file buf)))
+  (balance-windows))
+
+(defun helm-ext-ff-execute-horizontal-split ()
+  (interactive)
+  (with-helm-alive-p
+    (helm-exit-and-execute-action 'helm-ext-ff-action-horizontal-split)))
+
+(defun helm-ext-ff-execute-vertical-split ()
+  (interactive)
+  (with-helm-alive-p
+    (helm-exit-and-execute-action 'helm-ext-ff-action-vertical-split)))
+
 (provide 'helm-ext-ff)
 ;;; helm-ext-ff.el ends here

--- a/helm-ext.el
+++ b/helm-ext.el
@@ -218,14 +218,11 @@
                      helm-ext-ff--buffer-horizontal-split-action t)
         (add-to-list 'helm-type-buffer-actions
                      helm-ext-ff--buffer-vertical-split-action t)
-        (define-key helm-find-files-map
-          (kbd helm-ext-ff-horizontal-split-key) #'helm-ext-ff-execute-horizontal-split)
-        (define-key helm-buffer-map
-          (kbd helm-ext-ff-horizontal-split-key) #'helm-ext-ff-execute-horizontal-split)
-        (define-key helm-find-files-map
-          (kbd helm-ext-ff-vertical-split-key) #'helm-ext-ff-execute-vertical-split)
-        (define-key helm-buffer-map
-          (kbd helm-ext-ff-vertical-split-key) #'helm-ext-ff-execute-vertical-split))
+        (dolist (keymap helm-ext-ff-split-actions-keymaps)
+          (define-key keymap
+            (kbd helm-ext-ff-horizontal-split-key) #'helm-ext-ff-execute-horizontal-split)
+          (define-key keymap
+            (kbd helm-ext-ff-vertical-split-key) #'helm-ext-ff-execute-vertical-split)))
     (setq helm-find-files-actions
           (delete helm-ext-ff--horizontal-split-action
                   helm-find-files-actions))
@@ -238,14 +235,11 @@
     (setq helm-type-buffer-actions
           (delete helm-ext-ff--buffer-vertical-split-action
                   helm-type-buffer-actions))
-    (define-key helm-find-files-map
-      (kbd helm-ext-ff-horizontal-split-key) nil)
-    (define-key helm-buffer-map
-      (kbd helm-ext-ff-horizontal-split-key) nil)
-    (define-key helm-find-files-map
-      (kbd helm-ext-ff-vertical-split-key) nil)
-    (define-key helm-buffer-map
-      (kbd helm-ext-ff-vertical-split-key) nil)))
+    (dolist (keymap helm-ext-ff-split-actions-keymaps)
+      (define-key keymap
+        (kbd helm-ext-ff-horizontal-split-key) nil)
+      (define-key keymap
+        (kbd helm-ext-ff-vertical-split-key) nil))))
 
 ;;;###autoload
 (defun helm-ext-minibuffer-enable-header-line-maybe (enable)

--- a/helm-ext.el
+++ b/helm-ext.el
@@ -205,6 +205,49 @@
                    'helm-ext-ff-skip-dots)))
 
 ;;;###autoload
+(defun helm-ext-ff-enable-split-actions (enable)
+  (interactive)
+  (require 'helm-types)
+  (if enable
+      (progn
+        (add-to-list 'helm-find-files-actions
+                     helm-ext-ff--horizontal-split-action t)
+        (add-to-list 'helm-find-files-actions
+                     helm-ext-ff--vertical-split-action t)
+        (add-to-list 'helm-type-buffer-actions
+                     helm-ext-ff--buffer-horizontal-split-action t)
+        (add-to-list 'helm-type-buffer-actions
+                     helm-ext-ff--buffer-vertical-split-action t)
+        (define-key helm-find-files-map
+          (kbd helm-ext-ff-horizontal-split-key) #'helm-ext-ff-execute-horizontal-split)
+        (define-key helm-buffer-map
+          (kbd helm-ext-ff-horizontal-split-key) #'helm-ext-ff-execute-horizontal-split)
+        (define-key helm-find-files-map
+          (kbd helm-ext-ff-vertical-split-key) #'helm-ext-ff-execute-vertical-split)
+        (define-key helm-buffer-map
+          (kbd helm-ext-ff-vertical-split-key) #'helm-ext-ff-execute-vertical-split))
+    (setq helm-find-files-actions
+          (delete helm-ext-ff--horizontal-split-action
+                  helm-find-files-actions))
+    (setq helm-find-files-actions
+          (delete helm-ext-ff--vertical-split-action
+                  helm-find-files-actions))
+    (setq helm-type-buffer-actions
+          (delete helm-ext-ff--buffer-horizontal-split-action
+                  helm-type-buffer-actions))
+    (setq helm-type-buffer-actions
+          (delete helm-ext-ff--buffer-vertical-split-action
+                  helm-type-buffer-actions))
+    (define-key helm-find-files-map
+      (kbd helm-ext-ff-horizontal-split-key) nil)
+    (define-key helm-buffer-map
+      (kbd helm-ext-ff-horizontal-split-key) nil)
+    (define-key helm-find-files-map
+      (kbd helm-ext-ff-vertical-split-key) nil)
+    (define-key helm-buffer-map
+      (kbd helm-ext-ff-vertical-split-key) nil)))
+
+;;;###autoload
 (defun helm-ext-minibuffer-enable-header-line-maybe (enable)
   (if enable
       (add-hook 'helm-minibuffer-set-up-hook 'helm-ext--use-header-line-maybe)


### PR DESCRIPTION
cc @blaenk : I refactored the code a little bit. Let me know if there is any problem.

To solve the problem you mentioned in #4: opening a file behaves differently from `helm-find-files`, we need to hack `helm-find-file-or-marked`a little, which I haven't done yet.

Horizontal split key is now by default <kbd>C-c s h</kbd> (and <kbd>C-c s v</kbd> for vertical split). You can customize the keys. Users would expect <kbd>M-v</kbd> to be used for buffer scrolling and thus should be reserved. But you're free to use it anyway.

And yes, use `(helm-ext-ff-enable-split-actions t)` to enable the feature.

Thanks for your code! 